### PR TITLE
Add bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy review to bitcoin-magazine/bitcoin-explained

### DIFF
--- a/bitcoin-magazine/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
+++ b/bitcoin-magazine/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
@@ -1,10 +1,10 @@
 ---
-title: "Bitcoin Core 26.0 (And F2Pool’s OFAC Compliant Mining Policy)"
-transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+title: Bitcoin Core 26.0 (And F2Pool’s OFAC Compliant Mining Policy)
+transcript_by: kouloumos via review.btctranscripts.com
 media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-85-bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy-ainlt
 tags: ["mining"]
-speakers: ['Sjors Provoost', 'Aaron van Wirdum']
-categories: ['podcast']
+speakers: ["Sjors Provoost","Aaron van Wirdum"]
+categories: ["podcast"]
 date: 2023-11-23
 ---
 Speaker 0: 00:00:20

--- a/bitcoin-magazine/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
+++ b/bitcoin-magazine/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
@@ -2,7 +2,6 @@
 title: Bitcoin Core 26.0 (And F2Pool’s OFAC Compliant Mining Policy)
 transcript_by: kouloumos via review.btctranscripts.com
 media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-85-bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy-ainlt
-tags: ["mining"]
 speakers: ["Sjors Provoost","Aaron van Wirdum"]
 categories: ["podcast"]
 date: 2023-11-23
@@ -15,8 +14,6 @@ Hello Sjoerd.
 Speaker 1: 00:00:25
 
 What's up?
-Welcome back.
-Thank you.
 
 Speaker 0: 00:00:28
 


### PR DESCRIPTION
This PR adds [bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy](https://bitcoinexplainedpodcast.com/@nado/episodes/episode-85-bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy-ainlt) transcript review to the bitcoin-magazine/bitcoin-explained directory.